### PR TITLE
fix: only use lang if it's found

### DIFF
--- a/src/translate-cache.service.ts
+++ b/src/translate-cache.service.ts
@@ -49,7 +49,7 @@ export class TranslateCacheService {
 
         const currentLang = this.getCachedLanguage() || this.translateService.getBrowserLang();
 
-        if (currentLang) { this.translateService.use(currentLang); }
+        if (currentLang && this.translateService.getLangs().includes(currentLang)) { this.translateService.use(currentLang); }
     }
 
     public getCachedLanguage(): string {


### PR DESCRIPTION
a rebased and simplified copy of https://github.com/jgpacheco/ngx-translate-cache/pull/5