### PR TITLE
Revert "fix: only use lang if it's found (#9)"

### DIFF
--- a/src/translate-cache.service.ts
+++ b/src/translate-cache.service.ts
@@ -49,7 +49,7 @@ export class TranslateCacheService {
 
         const currentLang = this.getCachedLanguage() || this.translateService.getBrowserLang();
 
-        if (currentLang && this.translateService.getLangs().includes(currentLang)) { this.translateService.use(currentLang); }
+        if (currentLang) { this.translateService.use(currentLang); }
     }
 
     public getCachedLanguage(): string {


### PR DESCRIPTION
This reverts commit d741ccb655f253c9498baa9d4d76bb4538b2e3ed.

Doing some tests before publishing a new version including this change, I notice that when the application load,`getLangs` always return an empty array if `addLangs` is not explicitly called first (at least using TranslateHttpLoader). And since this condition (`this.translateService.getLangs().includes(currentLang)`) will be always false in that case, the cached language is never used. That defeat the purpose of this library.

Alternatively, we could use `getTranslation` instead of` getLangs` to determine if the language is available; but due to the asynchronous nature of the `getTranslation` method, the default language will load before that of the cache, causing the translated text to blink.