### PR TITLE
Add cookie session expiry and additional attribute support

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,8 @@ cookie duration (defined in hours).
               },
               cacheName: 'mylang', // default value is 'lang'.
               cacheMechanism: 'Cookie', // default value is 'LocalStorage'.
-              cookieExpiry: 1, // default value is 720, a month.
+              cookieExpiry: 1, // default value is 720, a month, or use 'COOKIE_EXPIRE_SESSION' for session expiry.
+              cookieAttributes: 'SameSite=Strict; Secure' // no default, optional specification of additional attributes.
             })
         ],
         ...

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ cookie duration (defined in hours).
               },
               cacheName: 'mylang', // default value is 'lang'.
               cacheMechanism: 'Cookie', // default value is 'LocalStorage'.
-              cookieExpiry: 1, // default value is 720, a month, or use 'COOKIE_EXPIRE_SESSION' for session expiry.
+              cookieExpiry: 1, // default value is 720, a month. Set to a negative value and the cookie becomes a session cookie.
               cookieAttributes: 'SameSite=Strict; Secure' // no default, optional specification of additional attributes.
             })
         ],

--- a/projects/ngx-translate-cache/src/lib/ngx-translate-cache.module.ts
+++ b/projects/ngx-translate-cache/src/lib/ngx-translate-cache.module.ts
@@ -1,7 +1,7 @@
 import { NgModule, ModuleWithProviders } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TranslateCacheConfig, CACHE_NAME, CACHE_MECHANISM, COOKIE_EXPIRY,
-  TranslateCacheSettings } from './ngx-translate-cache.service';
+  COOKIE_ATTRIBUTES, TranslateCacheSettings } from './ngx-translate-cache.service';
 
 @NgModule({
   imports: [
@@ -18,6 +18,7 @@ export class TranslateCacheModule {
         { provide: CACHE_NAME, useValue: config.cacheName },
         { provide: CACHE_MECHANISM, useValue: config.cacheMechanism },
         { provide: COOKIE_EXPIRY, useValue: config.cookieExpiry },
+        { provide: COOKIE_ATTRIBUTES, useValue: config.cookieAttributes },
         TranslateCacheSettings,
         config.cacheService,
       ]

--- a/projects/ngx-translate-cache/src/lib/ngx-translate-cache.service.ts
+++ b/projects/ngx-translate-cache/src/lib/ngx-translate-cache.service.ts
@@ -11,7 +11,6 @@ export const CACHE_NAME = new InjectionToken<string>('CACHE_NAME');
 export const CACHE_MECHANISM = new InjectionToken<string>('CACHE_MECHANISM');
 export const COOKIE_EXPIRY = new InjectionToken<string>('COOKIE_EXPIRY');
 export const COOKIE_ATTRIBUTES = new InjectionToken<string>('COOKIE_ATTRIBUTES');
-export const COOKIE_EXPIRE_SESSION = -1;
 
 export interface TranslateCacheConfig {
   cacheService: Provider;
@@ -84,7 +83,7 @@ export class TranslateCacheService {
       if (value) {
         let cookieString = `${name}=${encodeURIComponent(value)}`;
 
-        if (this.translateCacheSettings.cookieExpiry !== COOKIE_EXPIRE_SESSION) {
+        if (this.translateCacheSettings.cookieExpiry < 0) {
           const date: Date = new Date();
 
           date.setTime(date.getTime() + this.translateCacheSettings.cookieExpiry * 3600000);

--- a/projects/ngx-translate-cache/src/lib/ngx-translate-cache.service.ts
+++ b/projects/ngx-translate-cache/src/lib/ngx-translate-cache.service.ts
@@ -83,7 +83,7 @@ export class TranslateCacheService {
       if (value) {
         let cookieString = `${name}=${encodeURIComponent(value)}`;
 
-        if (this.translateCacheSettings.cookieExpiry < 0) {
+        if (this.translateCacheSettings.cookieExpiry >= 0) {
           const date: Date = new Date();
 
           date.setTime(date.getTime() + this.translateCacheSettings.cookieExpiry * 3600000);

--- a/projects/ngx-translate-cache/src/lib/ngx-translate-cache.service.ts
+++ b/projects/ngx-translate-cache/src/lib/ngx-translate-cache.service.ts
@@ -10,6 +10,7 @@ export namespace CacheMechanism {
 export const CACHE_NAME = new InjectionToken<string>('CACHE_NAME');
 export const CACHE_MECHANISM = new InjectionToken<string>('CACHE_MECHANISM');
 export const COOKIE_EXPIRY = new InjectionToken<string>('COOKIE_EXPIRY');
+export const COOKIE_ATTRIBUTES = new InjectionToken<string>('COOKIE_ATTRIBUTES');
 export const COOKIE_EXPIRE_SESSION = -1;
 
 export interface TranslateCacheConfig {
@@ -17,6 +18,7 @@ export interface TranslateCacheConfig {
   cacheName?: string;
   cacheMechanism?: CacheMechanismType;
   cookieExpiry?: number;
+  cookieAttributes?: string;
 }
 
 const DEFAULT_CACHE_NAME = 'lang';
@@ -27,7 +29,8 @@ const DEFAULT_COOKIE_EXPIRY = 720;
 export class TranslateCacheSettings {
   constructor(@Inject(CACHE_NAME) public cacheName: string = DEFAULT_CACHE_NAME,
               @Inject(CACHE_MECHANISM) public cacheMechanism: string = DEFAULT_CACHE_MECHANISM,
-              @Inject(COOKIE_EXPIRY) public cookieExpiry: number = DEFAULT_COOKIE_EXPIRY) {}
+              @Inject(COOKIE_EXPIRY) public cookieExpiry: number = DEFAULT_COOKIE_EXPIRY,
+              @Inject(COOKIE_ATTRIBUTES) public cookieAttributes: string) {}
 }
 
 /* Not injectable */
@@ -86,6 +89,10 @@ export class TranslateCacheService {
 
           date.setTime(date.getTime() + this.translateCacheSettings.cookieExpiry * 3600000);
           cookieString += `;expires=${date.toUTCString()}`;
+        }
+
+        if (this.translateCacheSettings.cookieAttributes) {
+          cookieString += ';' + this.translateCacheSettings.cookieAttributes;
         }
 
         document.cookie = cookieString;

--- a/projects/ngx-translate-cache/src/lib/ngx-translate-cache.service.ts
+++ b/projects/ngx-translate-cache/src/lib/ngx-translate-cache.service.ts
@@ -10,6 +10,7 @@ export namespace CacheMechanism {
 export const CACHE_NAME = new InjectionToken<string>('CACHE_NAME');
 export const CACHE_MECHANISM = new InjectionToken<string>('CACHE_MECHANISM');
 export const COOKIE_EXPIRY = new InjectionToken<string>('COOKIE_EXPIRY');
+export const COOKIE_EXPIRE_SESSION = -1;
 
 export interface TranslateCacheConfig {
   cacheService: Provider;
@@ -78,10 +79,16 @@ export class TranslateCacheService {
       const name = encodeURIComponent(this.translateCacheSettings.cacheName);
 
       if (value) {
-        const date: Date = new Date();
+        let cookieString = `${name}=${encodeURIComponent(value)}`;
 
-        date.setTime(date.getTime() + this.translateCacheSettings.cookieExpiry * 3600000);
-        document.cookie = `${name}=${encodeURIComponent(value)};expires=${date.toUTCString()}`;
+        if (this.translateCacheSettings.cookieExpiry !== COOKIE_EXPIRE_SESSION) {
+          const date: Date = new Date();
+
+          date.setTime(date.getTime() + this.translateCacheSettings.cookieExpiry * 3600000);
+          cookieString += `;expires=${date.toUTCString()}`;
+        }
+
+        document.cookie = cookieString;
 
         return;
       }


### PR DESCRIPTION
We required to change this library to provide cookie session expiry and additional attribute support.

The cookie session expiry support is enabled by using `COOKIE_SESSION_EXPIRE` constant, which is set to -1 as it's not an expiry value anyone would realistically use. The default is retained.

The additional attribute support is primarily to enable `SameSite=Strict; Secure` but offers flexibility to specify any additional attribute that may be desired. This is completely optional and merely appends to the normal construction of the cookie.

Updated README with instructions of usage.